### PR TITLE
docs: adopt agent decision comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Repository Guidelines
+
+## Agent Decision Comments
+
+This repository uses Agent Decision Comments (ADCs).
+Follow specification 0.1.0 at <https://github.com/dbrattli/adc>, currently
+pinned to commit `51310dbb60ba960890f431fe06ed701873eadb8b` because no upstream release or
+tag exists yet.
+
+ADCs are source-level comments using four directives:
+
+- `decision:` records a deliberate choice and its reason.
+- `invariant:` records a falsifiable property the code must preserve.
+- `assumption:` records an external belief the code does not guarantee.
+- `tradeoff:` records a cost accepted for a concrete benefit.
+
+Place ADCs in the nearest comment or documentation comment attached to the code
+they govern. Use one directive per line, present tense, and describe rationale
+that is not already evident from the implementation, types, or tests. In
+documentation comments, write normal API prose first and leave a blank line
+before the directives. Do not add ADCs mechanically to trivial code.
+
+Before modifying code, read all active ADCs in the affected scope.
+Preserve them or update them explicitly.
+Add comments for non-obvious decisions, invariants, assumptions, and tradeoffs
+introduced by a change.
+
+A change that introduces a non-obvious engineering decision or constraint is
+incomplete until its ADCs are present and consistent with the implementation.
+Reviewers evaluate the comments before reviewing the code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,9 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+Repository-wide contributor and Agent Decision Comment instructions live in
+`AGENTS.md`. Read and follow that file before modifying code.
+
 ## Project Overview
 
 Fable.Actor is a cross-platform actor library written in F# and compiled via [Fable](https://github.com/fable-compiler/Fable) to BEAM (Erlang), Python, and JavaScript. It provides typed actors with supervision, designed to be the foundation that Rx libraries (like AsyncRx) can build on.

--- a/examples/interop/erl/interop_demo.erl
+++ b/examples/interop/erl/interop_demo.erl
@@ -37,6 +37,8 @@ run() ->
     %% F# ReplyChannel<string> compiles to: #{reply => fun(V) -> ... end}
     %% Erlang can construct this map manually to call F# actors.
     io:format("  [Joe/Erlang] Asking Dag his full name (call pattern)...~n"),
+    %% decision: capture the caller before constructing the callback because it executes in Dag's process
+    %% invariant: every reply carries the unique ref used by the matching selective receive
     Ref = make_ref(),
     Me = self(),  %% Capture caller pid BEFORE the lambda (self() in lambda runs in callee's process!)
     Rc = #{reply => fun(V) -> Me ! {fable_actor_reply, Ref, V} end},

--- a/examples/interop/src/InteropExample.fs
+++ b/examples/interop/src/InteropExample.fs
@@ -5,6 +5,10 @@
 ///   - Actor.send wraps in {fable_actor_msg, Msg} envelope
 ///   - ReplyChannel compiles to #{reply => fun(V) -> ... end}
 ///   - Raw Erlang sends bypass the envelope
+///
+/// decision: demonstrates the wire protocol explicitly so native Erlang can interoperate without an F# adapter
+/// invariant: envelope and reply tags match Fable.Actor.Platform.InternalMsg
+/// assumption: Fable preserves the documented DU tuple and record map representations
 module InteropExample
 
 open Fable.Core
@@ -31,7 +35,10 @@ type DagMsg =
 
 // --- Dag: the F# actor ---
 
-/// Start Dag. He keeps Joe's raw pid as state so he can reply.
+/// Start Dag and keep Joe's raw pid as private actor state.
+///
+/// decision: replies to HelloFrom with a raw Erlang message to demonstrate bypassing the actor envelope
+/// invariant: AskName replies through ReplyChannel while HelloFrom replies directly to joePid
 let startDag (joePid: obj) : Actor<DagMsg * ReplyChannel<string>> =
     Actor.start joePid (fun joePid (msg, rc) ->
         match msg with

--- a/examples/timeflies-beam/src/erl/fable_actor_timeflies_ws.erl
+++ b/examples/timeflies-beam/src/erl/fable_actor_timeflies_ws.erl
@@ -19,6 +19,8 @@ websocket_init(_State) ->
     Distributor = timeflies_src_timeflies:setup_pipeline(SendFn),
     {ok, #{distributor => Distributor}}.
 
+%% decision: sends the Fable.Actor envelope directly to demonstrate native Erlang interoperability
+%% invariant: the message tag and MousePos map keys match the compiled F# wire representation
 websocket_handle({text, Json}, State) ->
     case jsx:decode(Json, [return_maps]) of
         #{<<"x">> := X, <<"y">> := Y} when is_integer(X), is_integer(Y) ->

--- a/examples/timeflies-js/src/App.fs
+++ b/examples/timeflies-js/src/App.fs
@@ -18,9 +18,9 @@ let getField (o: obj) (key: string) : obj = nativeOnly
 
 [<ReactComponent>]
 let App () =
-    // Mutable positions (actors update this directly)
+    // decision: stores positions in a ref and uses one scalar state value to trigger React rendering
+    // tradeoff: mutates a component-local array to avoid copying every position for each letter update
     let posRef = React.useRef (Array.init Timeflies.text.Length (fun _ -> (-100, -100)))
-    // Counter to trigger re-renders
     let _, setTick = React.useState 0
     let tickRef = React.useRef 0
 

--- a/examples/timeflies-python/src/Program.fs
+++ b/examples/timeflies-python/src/Program.fs
@@ -48,7 +48,9 @@ let mainAsync =
         )
         |> ignore
 
-        // Async main loop: process tkinter events + yield to asyncio
+        // decision: pumps Tk without blocking and yields explicitly so actor work shares the asyncio thread
+        // invariant: each loop drains pending Tk events before yielding to asyncio
+        // tradeoff: polls every 5 ms to integrate two event loops without another thread
         while true do
             while root.dooneevent (int Flags.DONT_WAIT) do
                 ()

--- a/examples/timeflies/src/Timeflies.fs
+++ b/examples/timeflies/src/Timeflies.fs
@@ -17,6 +17,10 @@ type LetterMsg =
 /// A distributor actor fans out mouse events to all letter actors.
 /// Returns the distributor actor — send MousePos to it.
 /// Kill the distributor to clean up (linked children die automatically).
+///
+/// decision: gives each letter a linked actor so delay and lifecycle remain isolated per letter
+/// invariant: only Delayed messages emit positions; MouseMove messages schedule them back to the same actor
+/// tradeoff: creates one actor and timer per letter to make the actor topology visible in the demo
 let setupPipeline (sendFn: string -> unit) : Actor<MousePos> =
     Actor.spawn (fun inbox ->
         // Each letter is a linked child actor with a delay

--- a/justfile
+++ b/justfile
@@ -3,6 +3,8 @@
 # Development mode: compile with a local Fable checkout instead of the pinned dotnet tool.
 # Whatever branch that checkout has out is what gets used — every backend lives in one repo.
 # Usage: just dev=true test-beam
+# decision: switches every backend through one fable variable so dev mode cannot silently mix compiler versions
+# assumption: the sibling ../Fable checkout contains src/Fable.Cli when dev=true
 dev := "false"
 fable_repo := justfile_directory() / "../Fable"
 fable := if dev == "true" { "dotnet run --project " + fable_repo / "src/Fable.Cli" + " --" } else { "dotnet fable" }
@@ -68,6 +70,9 @@ shipit *args:
 
 # One suite in test/, compiled to each target from the same project. Assertions come from
 # Scriptorium.Nib, the runner from Scriptorium.Quill.
+# decision: compiles one test project to all targets because the library itself has one conditional project
+# invariant: every test recipe executes the same F# suite through its target runtime
+# tradeoff: target-specific setup stays in recipes and Helpers.fs to prevent divergent suites
 
 # Run the behavioral suite on every target (.NET + Python + JS + BEAM)
 test: test-native test-python test-js test-beam

--- a/src/Fable.Actor/Actor.fs
+++ b/src/Fable.Actor/Actor.fs
@@ -6,6 +6,10 @@
 // Actor<'Msg> provides MailboxProcessor-compatible API:
 //   inbox.Receive() — get next message (inside body)
 //   actor.Post(msg)  — send a message (from outside)
+//
+// decision: presents one actor API while selecting native BEAM processes or MailboxProcessor at compile time
+// invariant: actors exchange state across process boundaries only through messages
+// tradeoff: maintains two runtime implementations to preserve each target's native concurrency semantics
 namespace Fable.Actor
 
 open Fable.Actor.Types
@@ -20,6 +24,12 @@ open Fable.Beam
 open Fable.Actor.Platform
 
 // === BEAM: CPS-based, native processes ===
+
+/// A synchronous continuation chain for an operation running inside one BEAM process.
+///
+/// decision: represents BEAM actor operations as CPS because receive blocks the lightweight process natively
+/// invariant: a successfully completed operation invokes its continuation exactly once before Run returns
+/// tradeoff: uses a target-specific computation type to avoid introducing an async scheduler on BEAM
 
 type ActorOp<'T> = { Run: ('T -> unit) -> unit }
 
@@ -56,11 +66,11 @@ type ActorBuilder() =
                     (handler ex).Run cont
     }
 
-    /// CPS try/finally. BEAM ops invoke their continuation synchronously, so we
-    /// capture the body's result via an inner continuation, run the compensation,
-    /// and only then call the outer continuation — otherwise the compensation
-    /// would run *after* the rest of the actor body, not when the body completes.
-    /// The compensation runs exactly once, on both normal and exceptional exit.
+    /// Run cleanup when a CPS body completes or raises.
+    ///
+    /// decision: captures the result before continuing so compensation precedes the rest of the actor body
+    /// invariant: compensation runs exactly once on both normal and exceptional completion
+    /// assumption: ActorOp continuations run synchronously — delayed continuation would expose an uninitialized result
     member _.TryFinally(body: ActorOp<'T>, compensation: unit -> unit) : ActorOp<'T> = {
         Run =
             fun cont ->
@@ -91,12 +101,11 @@ type ActorBuilder() =
     member this.For(items: seq<'T>, body: 'T -> ActorOp<unit>) : ActorOp<unit> =
         this.Using(items.GetEnumerator(), fun enum -> this.While((fun () -> enum.MoveNext()), this.Delay(fun () -> body enum.Current)))
 
-    /// Bridge an Async into the actor CE. On BEAM, Async is erased to synchronous
-    /// callbacks (there is no async scheduler — concurrency comes from spawning
-    /// actors, and Async.Parallel, not from sequential Async), so running it to
-    /// completion via Async.RunSynchronously simply executes the callback chain the
-    /// async already is — inline in this process. This makes `do! someAsyncCall`
-    /// work inside actor { }. BEAM-only: on other targets ActorOp = Async natively.
+    /// Bridge an Async into the actor CE.
+    ///
+    /// decision: runs sequential Async inline so Async-returning APIs compose inside actor expressions
+    /// assumption: Fable.Beam erases sequential Async to synchronous callbacks; Async.Parallel is the spawning exception
+    /// tradeoff: supports shared Async APIs but does not add scheduler-based concurrency to a BEAM actor
     member _.Bind(op: Async<'T>, f: 'T -> ActorOp<'U>) : ActorOp<'U> = {
         Run = fun cont -> (f (Async.RunSynchronously op)).Run cont
     }
@@ -104,6 +113,9 @@ type ActorBuilder() =
 #else
 
 // === Non-BEAM: MailboxProcessor-based ===
+
+// decision: aliases actor operations to Async so existing Fable runtimes provide scheduling and cancellation
+// invariant: ActorBuilder delegates control-flow semantics to the standard async builder on non-BEAM targets
 
 type ActorOp<'T> = Async<'T>
 
@@ -116,6 +128,9 @@ type Actor<'Msg> = {
 
     member this.Receive() : Async<'Msg> = this.Mb.Receive()
 
+    /// Queue a message unless this actor has already been killed.
+    ///
+    /// invariant: posting after cancellation is a no-op rather than an exception
     member this.Post(msg: 'Msg) =
         if not this.Cts.IsCancellationRequested then
             this.Mb.Post(msg)
@@ -141,7 +156,11 @@ type ActorBuilder() =
 
 #endif
 
-/// A supervised child — wraps an actor ref with restart capability.
+/// A supervised child with the information required to restart it.
+///
+/// decision: retains the body and mutates the public actor handle so callers can follow restarts through one value
+/// invariant: Actor refers to the latest child after handleChildExit returns true
+/// tradeoff: the stable wrapper contains mutable state to keep the restarted actor address current
 type SupervisedChild<'ParentMsg, 'Msg> = {
     mutable Actor: Actor<'Msg>
     Body: Actor<'Msg> -> ActorOp<unit>
@@ -171,6 +190,8 @@ module Actor =
         { Pid = rawPid }
 
     /// Spawn a linked child actor (parent gets EXIT signal on crash).
+    ///
+    /// assumption: the caller is the supplied parent process — BEAM links the child to the calling process
     let spawnLinked (_parent: Actor<'ParentMsg>) (body: Actor<'Msg> -> ActorOp<unit>) : Actor<'Msg> =
         let rawPid =
             Erlang.spawnLink (fun () ->
@@ -186,12 +207,17 @@ module Actor =
     let kill (actor: Actor<'Msg>) : unit = killProcess actor.Pid
 
     /// Enable supervision — child EXIT signals become messages.
+    ///
+    /// assumption: called inside the supervising actor because trap_exit affects only the current BEAM process
     let trapExits () : unit = Platform.trapExits ()
 
     /// Format a crash reason as a string.
     let formatReason (reason: obj) : string = Platform.formatReason reason
 
     /// Send a message and await a reply (inside actor { }).
+    ///
+    /// decision: correlates every call with a fresh Erlang ref so concurrent replies cannot be confused
+    /// invariant: waiting for this call consumes only the reply carrying its ref
     let call (actor: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : ActorOp<'Reply> = {
         Run =
             fun cont ->
@@ -206,9 +232,10 @@ module Actor =
                 cont (recvReply ref)
     }
 
-    /// Send a message and await a reply as an Async (usable from async { } contexts).
-    /// BEAM processes block natively, so the CPS Run continuation fires synchronously
-    /// once the reply arrives — capture it and return.
+    /// Send a message and await a reply as an Async (usable from async expressions).
+    ///
+    /// decision: captures the synchronous CPS result to bridge ActorOp back into shared Async-based APIs
+    /// assumption: call invokes its continuation synchronously after the blocking BEAM receive completes
     let callAsync (actor: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : Async<'Reply> =
         async {
             let mutable result = Unchecked.defaultof<'Reply>
@@ -218,6 +245,8 @@ module Actor =
 
     /// Send a message and await a reply with a timeout in milliseconds.
     /// Raises TimeoutException if no reply is received within the timeout.
+    ///
+    /// invariant: the selective receive leaves unrelated mailbox messages untouched
     let callWithTimeout (timeout: int) (actor: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : ActorOp<'Reply> = {
         Run =
             fun cont ->
@@ -244,6 +273,9 @@ module Actor =
 
     /// Spawn an actor with an optional external cancellation token.
     /// When the external token is cancelled, the actor's CTS is also cancelled.
+    ///
+    /// decision: links external cancellation to a private CTS instead of putting the token in the actor's Async context
+    /// invariant: cancelling the external token prevents subsequent posts through the returned actor handle
     let spawnWithToken (cancellationToken: System.Threading.CancellationToken) (body: Actor<'Msg> -> Async<unit>) : Actor<'Msg> =
         let cts = new System.Threading.CancellationTokenSource()
 
@@ -263,6 +295,8 @@ module Actor =
         | None -> { Mb = mb; Cts = cts }
 
     /// Spawn an actor. Body receives inbox (self-reference) for Receive/Post.
+    ///
+    /// decision: owns a private CTS for explicit kill semantics without polluting operations in the actor body
     let spawn (body: Actor<'Msg> -> Async<unit>) : Actor<'Msg> =
         let cts = new System.Threading.CancellationTokenSource()
         let mutable inbox: Actor<'Msg> option = None
@@ -278,6 +312,9 @@ module Actor =
         | None -> { Mb = mb; Cts = cts }
 
     /// Spawn a linked child actor. On crash, delivers ChildExited to parent.
+    ///
+    /// decision: emulates BEAM links by converting an unhandled body exception into a message to the parent
+    /// invariant: normal body completion does not emit ChildExited on non-BEAM targets
     let spawnLinked (parent: Actor<'ParentMsg>) (body: Actor<'Msg> -> Async<unit>) : Actor<'Msg> =
         let cts = new System.Threading.CancellationTokenSource()
         let mutable inbox: Actor<'Msg> option = None
@@ -298,12 +335,16 @@ module Actor =
         | Some a -> a
         | None -> { Mb = mb; Cts = cts }
 
-    /// Kill an actor — cancels its token and disposes the MailboxProcessor.
+    /// Kill an actor by cancelling its lifecycle and disposing its mailbox.
+    ///
+    /// invariant: after kill returns, Post ignores new messages through this handle
     let kill (actor: Actor<'Msg>) : unit =
         actor.Cts.Cancel()
         (actor.Mb :> System.IDisposable).Dispose()
 
     /// Enable supervision (stub on non-BEAM).
+    ///
+    /// decision: remains a no-op because spawnLinked already converts non-BEAM child crashes into messages
     let trapExits () : unit = ()
 
     /// Send a message and await a reply (inside actor { }).
@@ -320,6 +361,9 @@ module Actor =
 
     /// Send a message and await a reply with a timeout in milliseconds.
     /// Raises TimeoutException if no reply is received within the timeout.
+    ///
+    /// decision: polls a ReplyChannel every 5 ms because the portable path cannot use MailboxProcessor timeout overloads
+    /// tradeoff: timeout detection can lag by one polling interval to keep one implementation for .NET, Python, and JS
     let callWithTimeout (timeout: int) (target: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : ActorOp<'Reply> =
         let mutable result: 'Reply option = None
         let rc: ReplyChannel<'Reply> = { Reply = fun r -> result <- Some r }
@@ -374,8 +418,11 @@ module Actor =
         }
 
     /// Handle a ChildExited event for a supervised child.
-    /// Returns true if the child was restarted, false if stopped/not matching.
+    /// Returns true if the child was restarted and false if it was stopped.
     /// Raises ProcessExitException if Escalate.
+    ///
+    /// assumption: exited belongs to supervised — this function does not compare their process identifiers
+    /// invariant: Restart replaces supervised.Actor before returning true
     let handleChildExit (parent: Actor<'ParentMsg>) (supervised: SupervisedChild<'ParentMsg, 'Msg>) (exited: ChildExited) : bool =
         let (OneForOne decider) = supervised.Strategy
 
@@ -415,8 +462,11 @@ module Actor =
         }
 
     /// Handle a ChildExited event for a supervised child.
-    /// Returns true if the child was restarted, false if stopped/not matching.
+    /// Returns true if the child was restarted and false if it was stopped.
     /// Raises ProcessExitException if Escalate.
+    ///
+    /// assumption: exited belongs to supervised — this function does not compare their process identifiers
+    /// invariant: Restart replaces supervised.Actor before returning true
     let handleChildExit (parent: Actor<'ParentMsg>) (supervised: SupervisedChild<'ParentMsg, 'Msg>) (exited: ChildExited) : bool =
         let (OneForOne decider) = supervised.Strategy
 
@@ -441,10 +491,15 @@ module Actor =
     let send (actor: Actor<'Msg>) (msg: 'Msg) : unit = actor.Post(msg)
 
     /// Fire-and-forget message to a call-capable actor (no-op reply channel).
+    ///
+    /// decision: supplies a no-op channel so one actor protocol can accept both casts and calls
     let cast (actor: Actor<'Msg * ReplyChannel<'Reply>>) (msg: 'Msg) : unit =
         actor.Post((msg, { Reply = fun _ -> () }))
 
     /// Start a stateful actor with a message handler.
+    ///
+    /// decision: threads state through a single receive loop so updates remain private and serialized
+    /// invariant: the next message is not handled until the current handler returns its Next value
     let start (initialState: 'State) (handler: 'State -> 'Msg -> Next<'State>) : Actor<'Msg> =
         let body (inbox: Actor<'Msg>) =
             let rec loop state =
@@ -500,7 +555,10 @@ module Actor =
 
 #endif
 
-    /// Extract the raw platform handle from an actor.
+    /// Extract the raw platform handle from an actor for native interoperability.
+    ///
+    /// decision: exposes an explicit escape hatch while keeping ordinary messaging behind the typed Actor wrapper
+    /// tradeoff: the returned handle is target-specific and is not portable application state
 #if FABLE_COMPILER_BEAM
     let pid (actor: Actor<'Msg>) : Pid<'Msg> = actor.Pid
 #else

--- a/src/Fable.Actor/Platform.fs
+++ b/src/Fable.Actor/Platform.fs
@@ -2,6 +2,9 @@
 ///
 /// Delegates to Fable.Beam.Erlang for standard BIFs and keeps only
 /// actor-specific protocol Emits (tagged messages, selective receive).
+///
+/// decision: uses typed Fable.Beam bindings except where selective receive requires bound Erlang variables
+/// invariant: public actor messages and replies retain their established Erlang envelope tags
 module Fable.Actor.Platform
 
 #if FABLE_COMPILER_BEAM
@@ -30,10 +33,10 @@ let formatReason (reason: obj) : string = Erlang.formatTerm reason
 // Internal message protocol
 // ============================================================================
 
-/// DU mapping the tagged-tuple envelope used on the wire.
-/// Each case's CompiledName matches the Erlang atom tag, so a typed
-/// `Erlang.receive<InternalMsg>()` compiles to the selective receive
-/// `receive {fable_actor_msg, ...}; {'EXIT', ...} end`.
+/// Tagged-tuple envelopes used by the BEAM wire protocol.
+///
+/// decision: models envelopes as a DU so send and receive derive the same tags from one typed definition
+/// invariant: CompiledName values match the tags consumed by native Erlang interoperability code
 type InternalMsg =
     | [<CompiledName("fable_actor_msg")>] ActorMsg of payload: obj
     | [<CompiledName("fable_actor_reply")>] Reply of ref: Ref<obj> * value: obj
@@ -53,8 +56,10 @@ let sendMsg (pid: Pid<'Msg>) (msg: 'Msg) : unit =
 let sendReply (pid: Pid<'Caller>) (ref: Ref<'Reply>) (value: 'Reply) : unit =
     Erlang.send (unbox<Pid<InternalMsg>> pid) (Reply(unbox<Ref<obj>> ref, box value))
 
-/// CPS receive: blocks until a user message arrives, passing EXIT signals
-/// through transparently as ChildExited (a normal exit is ignored).
+/// Block until a user message or abnormal child exit is available.
+///
+/// decision: drops stale replies and normal exits because neither is an application message
+/// invariant: abnormal EXIT signals reach the actor body as ChildExited values
 let rec receiveMsg (cont: obj -> unit) : unit =
     match Erlang.receive<InternalMsg> () with
     | ActorMsg payload -> cont payload
@@ -62,14 +67,16 @@ let rec receiveMsg (cont: obj -> unit) : unit =
     | Exit(_, reason) when Erlang.exactEquals reason atomNormal -> receiveMsg cont
     | Exit(pid, reason) -> cont (box ({ Pid = box pid; Reason = reason }: ChildExited))
 
-/// Blocking selective receive for a reply matching a specific ref.
-/// Uses emitErlExpr to preserve Erlang's bound-variable semantics —
-/// only the message with the matching ref is consumed from the mailbox.
+/// Block until the reply matching a specific ref arrives.
+///
+/// decision: emits the receive expression directly to preserve Erlang bound-variable matching semantics
+/// invariant: replies with other refs remain in the mailbox
 let recvReply (ref: Ref<'Reply>) : 'Reply =
     emitErlExpr ref "receive {fable_actor_reply, $0, FableReply} -> FableReply end"
 
-/// Selective receive for a reply with timeout.
-/// Returns Some(reply) or None on timeout.
+/// Selectively receive a reply or return None after the timeout.
+///
+/// invariant: timing out does not consume a late or unrelated reply
 let recvReplyWithTimeout (ref: Ref<'Reply>) (timeout: int) : 'Reply option =
     emitErlExpr (ref, timeout) "receive {fable_actor_reply, $0, FableReply} -> {some, FableReply} after $1 -> undefined end"
 
@@ -86,8 +93,10 @@ let isChildExited (msg: obj) : bool = nativeOnly
 
 type private TimerControl = | [<CompiledName("cancel")>] Cancel
 
-/// Schedule a callback after ms milliseconds.
-/// Returns the timer process pid (boxed) for cancellation.
+/// Schedule a callback after ms milliseconds and return its process for cancellation.
+///
+/// decision: gives each timer a process so cancellation uses ordinary BEAM messaging
+/// tradeoff: allocates one lightweight process per timer to avoid a shared timer registry
 let timerSchedule (ms: int) (callback: unit -> unit) : obj =
     let pid: Pid<TimerControl> =
         Erlang.spawn (fun () ->

--- a/src/Fable.Actor/Types.fs
+++ b/src/Fable.Actor/Types.fs
@@ -6,19 +6,28 @@ module Fable.Actor.Types
 open Fable.Core
 
 /// A reply channel that the receiver calls to send a response back to the caller.
+///
+/// decision: uses a callback record instead of AsyncReplyChannel so the call protocol compiles to every target
 type ReplyChannel<'Reply> = { Reply: 'Reply -> unit }
 
-/// Opaque handle for a scheduled timer (erased to the platform-native handle).
+/// Opaque handle for a scheduled timer.
+///
+/// decision: erases the wrapper so each target can retain its native cancellation handle without exposing it
 [<Erase>]
 type TimerHandle = TimerHandle of obj
 
 /// What the actor should do after handling a message.
+///
+/// decision: makes normal and abnormal termination explicit handler results so supervision can distinguish them
+/// invariant: StopAbnormal raises its exception from the actor loop and therefore triggers linked supervision
 type Next<'State> =
     | Continue of 'State
     | Stop
     | StopAbnormal of exn
 
 /// Notification when a child actor dies.
+///
+/// decision: keeps pid and reason opaque because their runtime representations differ across targets
 type ChildExited = { Pid: obj; Reason: obj }
 
 exception ProcessExitException of string
@@ -31,4 +40,6 @@ type Directive =
     | Escalate
 
 /// Supervision strategy — consulted when a child crashes.
+///
+/// decision: starts with one-for-one supervision because each SupervisedChild owns one independently restartable body
 type Strategy = OneForOne of decider: (exn -> Directive)

--- a/test/Helpers.fs
+++ b/test/Helpers.fs
@@ -7,6 +7,9 @@ open Fable.Actor.Types
 // Scriptorium (Nib + Quill); what is left here is the glue the suite needs to drive actors —
 // a per-target sleep, the bridge that hands an `ActorOp` to Quill (which speaks `Async`), and a
 // reporter actor for observing state that has to cross a process boundary on BEAM.
+//
+// decision: keeps one behavioral suite for every target so platform branches must satisfy the same API contract
+// invariant: target-specific test plumbing remains contained in this module
 [<AutoOpen>]
 module Helpers =
 
@@ -29,9 +32,10 @@ module Helpers =
             return ()
         }
 
-    /// Bridge an `ActorOp` into the `Async` that Quill's `testAsync` expects. On BEAM `ActorOp`
-    /// is a CPS record and `Async` is erased to synchronous callbacks, so running the
-    /// continuation chain inline is all there is to do — there is no scheduler to hand it to.
+    /// Bridge an ActorOp into the Async that Quill expects.
+    ///
+    /// decision: runs the CPS continuation inline because BEAM Async is erased to synchronous callbacks
+    /// assumption: the operation completes synchronously on BEAM before the returned Async completes
     let toAsync (op: ActorOp<unit>) : Async<unit> = async { op.Run(fun () -> ()) }
 
 #else
@@ -44,10 +48,10 @@ module Helpers =
 
 #endif
 
-    /// A reporter actor: a one-cell mailbox for state that has to cross a process boundary.
-    /// On BEAM a `let mutable` captured by a spawned actor is a copy, so a test publishes its
-    /// observation with `Actor.cast reporter (Some v)` and reads it back with
-    /// `Actor.call reporter None`.
+    /// A one-cell actor for observing state across a process boundary.
+    ///
+    /// decision: reports observations through messages because BEAM actors copy captured mutable values
+    /// invariant: Some replaces the cell and None replies with its latest value
     let reporter initial =
         Actor.start initial (fun state (msg, rc) ->
             match msg with


### PR DESCRIPTION
## Summary

- adopt Agent Decision Comments specification 0.1.0 in `AGENTS.md`
- make `CLAUDE.md` defer to the repository-wide agent instructions
- add focused `decision:`, `invariant:`, `assumption:`, and `tradeoff:` comments to the public API and core runtime
- document cross-target test/build constraints and representative interop and UI boundaries

## Why

Fable.Actor has several non-obvious portability and lifecycle choices that are difficult to recover from types and tests alone. Keeping concise rationale beside the governed code helps reviewers and future coding agents preserve those constraints.

## Impact

This is a documentation-only change. It does not alter runtime behavior or public signatures.

## Validation

- `just format`
- `just check`
- 28/28 tests on .NET
- 28/28 tests on Python
- 28/28 tests on JavaScript
- 28/28 tests on BEAM
- `git diff --check`
