### PR TITLE
fix: upgrade Fable.Beam to rc.37

### DIFF
--- a/examples/timeflies-beam/src/App.fs
+++ b/examples/timeflies-beam/src/App.fs
@@ -22,4 +22,4 @@ let start () =
     startClear (Erlang.binaryToAtom "timeflies_listener") (tcpPort 3000) (protocolOpts dispatch)
     |> ignore
 
-    io.format ("Timeflies demo running at http://localhost:3000~n", [])
+    format "Timeflies demo running at http://localhost:3000~n" []

--- a/examples/timeflies-beam/src/Timeflies.fsproj
+++ b/examples/timeflies-beam/src/Timeflies.fsproj
@@ -8,7 +8,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../timeflies/src/Timeflies.Common.fsproj" />
-    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.34" />
+    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.37" />
     <PackageReference Include="Fable.Beam.Cowboy" Version="5.0.0-rc.24" />
   </ItemGroup>
 </Project>

--- a/src/Fable.Actor/Fable.Actor.fsproj
+++ b/src/Fable.Actor/Fable.Actor.fsproj
@@ -22,7 +22,7 @@
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.*" />
+    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.37" />
     <PackageReference Include="Fable.Core" Version="5.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- pin Fable.Beam to 5.0.0-rc.37
- update the Timeflies I/O call to the typed rc.37 API

## Validation
- just check
- dotnet build examples/timeflies-beam/src/Timeflies.fsproj -m:1
- just test